### PR TITLE
Add Apache Syncope

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1046,7 +1046,7 @@ Etag: W/"e180ee84f0671b1"
 								Yes
 							</td>
 							<td>
-								Yes, Apache Software Foundation
+								Yes
 							</td>
 							<td>
 								Habart Thierry
@@ -1073,6 +1073,26 @@ Etag: W/"e180ee84f0671b1"
 							</td>
 							<td>
 								<a href="http://confluence.soffid.org/display/SOF/SCIM">http://confluence.soffid.org/display/SOF/SCIM</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								Syncope
+							</td>
+							<td>
+								Yes
+							</td>
+							<td>
+								Yes
+							</td>
+							<td>
+								Yes, ASL 2.0
+							</td>
+							<td>
+								Apache Software Foundation
+							</td>
+							<td>
+								<a href="http://syncope.apache.org">http://syncope.apache.org/</a>
 							</td>
 						</tr>
 						<tr>


### PR DESCRIPTION
Apache Syncope [recently completed](https://issues.apache.org/jira/browse/SYNCOPE-152) its SCIM 2.0 implementation.

Side note: I'm also removing an erroneous attribution to the Apache Software Foundation for `SimpleIdentityServer`, which looks like built on top ASF projects, not being part of the ASF itself.