### PR TITLE
Fix http status code to 200 after GET /Users

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -288,7 +288,7 @@
               of Resources.
             </p>
             <div style="background: #ffffff; overflow:auto;width:auto;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;">
-              <pre style="margin: 0; line-height: 125%"><span style="color: #008800; font-weight: bold">HTTP</span><span style="color: #333333">/</span><span style="color: #6600EE; font-weight: bold">1.1</span> <span style="color: #6600EE; font-weight: bold">201</span> <span style="color: #FF0000; font-weight: bold">Created HTTP/1.1</span>
+              <pre style="margin: 0; line-height: 125%"><span style="color: #008800; font-weight: bold">HTTP</span><span style="color: #333333">/</span><span style="color: #6600EE; font-weight: bold">1.1</span> <span style="color: #6600EE; font-weight: bold">200</span> <span style="color: #FF0000; font-weight: bold">OK HTTP/1.1</span>
 <span style="color: #0000CC">Content-Type</span><span style="color: #333333">:</span> application/scim+json
 <span style="color: #0000CC">Location</span><span style="color: #333333">:</span> https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
 <span style="color: #0000CC">ETag</span><span style="color: #333333">:</span> W/&quot;e180ee84f0671b1&quot;


### PR DESCRIPTION
<img width="439" alt="Screenshot 2019-10-10 at 17 25 13" src="https://user-images.githubusercontent.com/1242610/66583037-f5957780-eb82-11e9-89bd-b309b3c65331.png">

The response to a get should be 200 OK, (see https://tools.ietf.org/html/rfc7644#section-3.4.1)