### PR TITLE
Keycloak does not support SCIM2

### DIFF
--- a/src/main/webapp/json/scim_v2_implementations.json
+++ b/src/main/webapp/json/scim_v2_implementations.json
@@ -129,14 +129,6 @@ const scim_v2_implementations = {
             "link": "https://unifysolutions.net/",
         },
         {
-            "project_name": "Keycloak",
-            "client": "No",
-            "server": "Yes",
-            "open_source": "Yes, ASL 2.0",
-            "developer": "Red Hat",
-            "link": "https://www.keycloak.org/",
-        },
-        {
             "project_name": "Microsoft Identity Manager SCIMv2 Management Agent",
             "client": "Yes",
             "server": "No, but with sample service provider and test tooling to simulate Microsoft Identity Manager",


### PR DESCRIPTION
SCIM2 support in Keycloak was requested 2016-02, but has so far not
been implemented, see: https://issues.jboss.org/browse/KEYCLOAK-2537