### PR TITLE
Add Blink SCIM 2.0 implementation details

### DIFF
--- a/src/main/webapp/json/scim_v2_implementations.json
+++ b/src/main/webapp/json/scim_v2_implementations.json
@@ -410,8 +410,8 @@ const scim_v2_implementations = {
         },
         {
             "project_name": "Blink",
-            "client": "Yes",
-            "server": "No",
+            "client": "No",
+            "server": "Yes",
             "open_source": "No",
             "developer": "Blink",
             "link": "https://developer.joinblink.com/reference#user",

--- a/src/main/webapp/json/scim_v2_implementations.json
+++ b/src/main/webapp/json/scim_v2_implementations.json
@@ -408,5 +408,13 @@ const scim_v2_implementations = {
             "developer": "Micro Focus",
             "link": "https://www.netiq.com/documentation/identity-manager-48-drivers/scim_driver/data/driver-for-scim.html",
         },
+        {
+            "project_name": "Blink",
+            "client": "Yes",
+            "server": "No",
+            "open_source": "No",
+            "developer": "Blink",
+            "link": "https://developer.joinblink.com/reference#user",
+        },
     ]
 };


### PR DESCRIPTION
The definition of client and server isn't listed anywhere, and from which tools have which selected it isn't 100% clear to me which the correct one is. Blink supports inbound user provisioning using SCIM 2.0 via our API. I've listed this as Client (i.e. inbound rather than outbound) but can correct if I've misinterpreted.