### PR TITLE
eTag and version should match in GET user example

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -291,7 +291,7 @@
               <pre style="margin: 0; line-height: 125%"><span style="color: #008800; font-weight: bold">HTTP</span><span style="color: #333333">/</span><span style="color: #6600EE; font-weight: bold">1.1</span> <span style="color: #6600EE; font-weight: bold">200</span> <span style="color: #FF0000; font-weight: bold">OK HTTP/1.1</span>
 <span style="color: #0000CC">Content-Type</span><span style="color: #333333">:</span> application/scim+json
 <span style="color: #0000CC">Location</span><span style="color: #333333">:</span> https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
-<span style="color: #0000CC">ETag</span><span style="color: #333333">:</span> W/&quot;e180ee84f0671b1&quot;
+<span style="color: #0000CC">ETag</span><span style="color: #333333">:</span> W/&quot;f250dd84f0671c3&quot;
 
 {
   <span style="color: #007700">&quot;schemas&quot;</span>: [<span style="background-color: #fff0f0">&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;</span>],


### PR DESCRIPTION
Fixes mismatched eTag/version in GET user example.

![image](https://user-images.githubusercontent.com/8890796/105554133-bb4add80-5cd4-11eb-8bf4-d93c8115bffd.png)
