### PR TITLE
Added Anaplan SCIM API to v2.0 implementations

### DIFF
--- a/src/main/webapp/json/scim_v2_implementations.json
+++ b/src/main/webapp/json/scim_v2_implementations.json
@@ -1,5 +1,13 @@
 const scim_v2_implementations = {
     "implementations": [
+	    {
+            "project_name": "Anaplan SCIM API",
+            "client": "No",
+            "server": "Yes",
+            "open_source": "No",
+            "developer": "Anaplan, Inc.",
+            "link": "https://scimapi.docs.apiary.io"
+        },
         {
             "project_name": "AWS SSO",
             "client": "No",


### PR DESCRIPTION
Added Anaplan SCIM API, here alternative link to the official Anaplan website: https://help.anaplan.com/f6a801cd-c253-4ab9-ba03-dac09fd71f7c-Anaplan-SCIM-API