### PR TITLE
Added FusionAuth SCIM implementation to list.

### DIFF
--- a/src/main/webapp/json/scim_v2_implementations.json
+++ b/src/main/webapp/json/scim_v2_implementations.json
@@ -513,6 +513,14 @@ const scim_v2_implementations = {
           "link": "https://docs.alexishr.com"
         },
         {
+            "project_name": "FusionAuth SCIM",
+            "client": "No",
+            "server": "Yes",
+            "open_source": "No",
+            "developer": "FusionAuth",
+            "link": "https://fusionauth.io/docs/v1/tech/core-concepts/scim"
+        },
+        {
           "project_name": "Calendly",
           "client": "No",
           "server": "Yes",


### PR DESCRIPTION
This adds FusionAuth, which recently released SCIM server support in version 1.36, to the list of implementations.