### PR TITLE
Redirect http to https

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -696,6 +696,7 @@
   <script src="json/scim_v1_implementations.json"></script>
   <script src="json/scim_v2_implementations.json"></script>
   <script src="script/implementations.js"></script>
+  <script>if (location.protocol !== "https:") location.protocol = "https:";</script>
 </body>
 
 </html>


### PR DESCRIPTION
Adding this script ensures that the site will always be served over `https`, which is not the case right now.

