### PR TITLE
Update scim_v2_implementations.json

### DIFF
--- a/site/json/scim_v2_implementations.json
+++ b/site/json/scim_v2_implementations.json
@@ -449,12 +449,12 @@ const scim_v2_implementations = {
             "link": "https://github.com/Captain-P-Goldfish/SCIM-SDK",
         },
         {
-            "project_name": "idaas.nl",
+            "project_name": "The SCIM Playground",
             "client": "Yes",
             "server": "Yes",
             "open_source": "Yes, MIT License",
             "developer": "Arie Timmerman",
-            "link": "https://www.idaas.nl/guide/scim.html",
+            "link": "https://scim.dev",
         },
         {
             "project_name": "scim-patch",


### PR DESCRIPTION
Replaced reference to idaas.nl with [scim.dev](https://scim.dev). The first project is inactive, the SCIM server part has moved to https://scim.dev